### PR TITLE
[6조(롤로,잭슨)] Step2 - PhotoLibrary 연동 (PhotoKit)

### DIFF
--- a/PhotoApps/PhotoApps/Base.lproj/Main.storyboard
+++ b/PhotoApps/PhotoApps/Base.lproj/Main.storyboard
@@ -33,7 +33,21 @@
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="vZZ-Uk-TdH">
                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iqm-13-mIE">
+                                                    <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                                </imageView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="iqm-13-mIE" firstAttribute="leading" secondItem="vZZ-Uk-TdH" secondAttribute="leading" id="LVw-bc-aWc"/>
+                                                <constraint firstAttribute="trailing" secondItem="iqm-13-mIE" secondAttribute="trailing" id="Lor-5j-fCS"/>
+                                                <constraint firstAttribute="bottom" secondItem="iqm-13-mIE" secondAttribute="bottom" id="a0Z-IX-PrI"/>
+                                                <constraint firstItem="iqm-13-mIE" firstAttribute="top" secondItem="vZZ-Uk-TdH" secondAttribute="top" id="o4Y-XH-Q0u"/>
+                                            </constraints>
                                         </collectionViewCellContentView>
+                                        <connections>
+                                            <outlet property="photoCellImageView" destination="iqm-13-mIE" id="dGX-Tu-GMf"/>
+                                        </connections>
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>

--- a/PhotoApps/PhotoApps/Base.lproj/Main.storyboard
+++ b/PhotoApps/PhotoApps/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="8TH-ys-8Ez">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
@@ -9,7 +9,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Photos-->
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="PhotoApps" customModuleProvider="target" sceneMemberID="viewController">
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="HIT-Pj-T8G">
-                                <rect key="frame" x="0.0" y="44" width="390" height="766"/>
+                                <rect key="frame" x="0.0" y="88" width="390" height="722"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Hp8-ch-u4T">
                                     <size key="itemSize" width="128" height="128"/>
@@ -47,13 +47,32 @@
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="HIT-Pj-T8G" secondAttribute="bottom" id="qrh-vP-QI1"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" title="Photos" id="p3f-Sp-ndB"/>
                     <connections>
                         <outlet property="collectionView" destination="HIT-Pj-T8G" id="IuO-yg-77e"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-241" y="126"/>
+            <point key="canvasLocation" x="687.69230769230762" y="125.82938388625591"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="d5k-dB-2LY">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="8TH-ys-8Ez" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Th5-yb-5pl">
+                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="zbp-0A-Zgc"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vEQ-D9-CQ2" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-241.53846153846152" y="125.82938388625591"/>
         </scene>
     </scenes>
     <resources>

--- a/PhotoApps/PhotoApps/Info.plist
+++ b/PhotoApps/PhotoApps/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>사진 권한을 요청합니다</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/PhotoApps/PhotoApps/MyCustomViewCell.swift
+++ b/PhotoApps/PhotoApps/MyCustomViewCell.swift
@@ -2,11 +2,13 @@
 //  MyCustomViewCell.swift
 //  PhotoApps
 //
-//  Created by jinseo park on 3/22/21.
+//  Created by jackson,eeeeesong on 3/22/21.
 //
 
 import UIKit
 
 class MyCustomViewCell: UICollectionViewCell {
-//    @IBOutlet weak var label : UILabel!
+    
+    @IBOutlet weak var photoCellImageView: UIImageView!
+    
 }

--- a/PhotoApps/PhotoApps/ViewController.swift
+++ b/PhotoApps/PhotoApps/ViewController.swift
@@ -70,10 +70,15 @@ extension ViewController: UICollectionViewDataSource {
     
     func getAssetThumbnail(asset: PHAsset) -> UIImage {
         let manager = PHImageManager()
+        
         let option = PHImageRequestOptions()
-        var thumbnail = UIImage()
         option.isSynchronous = true
-        manager.requestImage(for: asset, targetSize: CGSize.init(width: cellSizeUnit, height: cellSizeUnit), contentMode: .aspectFit, options: .none) { (result, _ ) in
+        option.resizeMode = .exact
+        
+        var thumbnail = UIImage()
+        let targetSize = CGSize(width: cellSizeUnit, height: cellSizeUnit)
+        
+        manager.requestImage(for: asset, targetSize: targetSize, contentMode: .aspectFill, options: option) { (result, _) in
             if let result = result {
                 thumbnail = result
             }

--- a/PhotoApps/PhotoApps/ViewController.swift
+++ b/PhotoApps/PhotoApps/ViewController.swift
@@ -11,80 +11,68 @@ import Photos
 class ViewController: UIViewController {
     
     @IBOutlet weak var collectionView: UICollectionView!
-        
-    private var numberOfItems = 40
-    private let cellSizeUnit: CGFloat = 100
-    private var randomColorCollection = [UIColor]()
-    private var allPhotoAssets : PHFetchResult<PHAsset>?
+    
+    private let cellSize = CGSize(width: 100, height: 100)
+    private var photoAssets : PHFetchResult<PHAsset>?
+    private var cellCount: Int!
 
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        randomColorCollection = generateRandomColors(count: numberOfItems)
-        
         self.collectionView.delegate = self
         self.collectionView.dataSource = self
         
-        let targetAlbums = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .any, options: .none)
-        
-        let album = targetAlbums.firstObject ?? PHAssetCollection()
-
-        self.allPhotoAssets = PHAsset.fetchAssets(in: album, options: .none)
-        self.numberOfItems = self.allPhotoAssets?.count ?? 0
+        configurePhotoAssets()
+        updateCellCount()
         
         registerPhotoLibrary()
-                
-        self.collectionView.reloadData()
-        
     }
-
-    private func generateRandomColors(count: Int) -> [UIColor] {
-        var colorCollection = [UIColor]()
-        
-        for _ in 0..<count {
-            let newColor = UIColor.init(red: CGFloat(drand48()),
-                                        green: CGFloat(drand48()),
-                                        blue: CGFloat(drand48()),
-                                        alpha: 1)
-            colorCollection.append(newColor)
-        }
-        return colorCollection
+    
+    private func configurePhotoAssets() {
+        let smartAlbumCollection = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .any, options: .none)
+        let allContents = smartAlbumCollection.firstObject ?? PHAssetCollection()
+        photoAssets = PHAsset.fetchAssets(in: allContents, options: .none)
+    }
+    
+    private func updateCellCount() {
+        cellCount = photoAssets?.count ?? 0
     }
 }
 
 extension ViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: cellSizeUnit, height: cellSizeUnit)
+        return cellSize
     }
 }
 
 extension ViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return numberOfItems
+        return cellCount
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let newCell = collectionView.dequeueReusableCell(withReuseIdentifier: "photoCell", for: indexPath) as! MyCustomViewCell
         
-        if let asset = allPhotoAssets?[numberOfItems - indexPath.row - 1] {
+        let photoIdxToShow = cellCount - indexPath.row - 1 //최신 항목부터 표시
+        
+        if let asset = photoAssets?[photoIdxToShow] {
             newCell.photoCellImageView.image = getAssetThumbnail(asset: asset)
         }
         
         return newCell
     }
     
-    func getAssetThumbnail(asset: PHAsset) -> UIImage {
-        let manager =  PHCachingImageManager() //PHImageManager()
+    private func getAssetThumbnail(asset: PHAsset) -> UIImage {
+        let manager =  PHCachingImageManager()
         
         let option = PHImageRequestOptions()
         option.isSynchronous = true
         option.resizeMode = .exact
         
         var thumbnail = UIImage()
-        let targetSize = CGSize(width: cellSizeUnit, height: cellSizeUnit)
                 
-        manager.requestImage(for: asset, targetSize: targetSize, contentMode: .aspectFill, options: option) { (result, _) in
+        manager.requestImage(for: asset, targetSize: cellSize, contentMode: .aspectFill, options: option) { (result, _) in
             if let result = result {
                 thumbnail = result
             }
@@ -92,7 +80,6 @@ extension ViewController: UICollectionViewDataSource {
         return thumbnail
     }
 }
-
 
 extension ViewController : PHPhotoLibraryChangeObserver {
     
@@ -102,13 +89,13 @@ extension ViewController : PHPhotoLibraryChangeObserver {
     
     func photoLibraryDidChange(_ changeInstance: PHChange) {
         
-        guard let asset = allPhotoAssets,
+        guard let asset = photoAssets,
               let changes = changeInstance.changeDetails(for: asset) else { return }
         
         OperationQueue.main.addOperation {
             
-            self.allPhotoAssets = changes.fetchResultAfterChanges
-            self.numberOfItems = self.allPhotoAssets?.count ?? 0
+            self.photoAssets = changes.fetchResultAfterChanges
+            self.updateCellCount()
         
             guard changes.hasIncrementalChanges else { //아주 큰 변화가 있을 시엔 전체를 reload해야 함
                 self.collectionView.reloadData()

--- a/PhotoApps/PhotoApps/ViewController.swift
+++ b/PhotoApps/PhotoApps/ViewController.swift
@@ -12,7 +12,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var collectionView: UICollectionView!
     
     private let numberOfItems = 40
-    private let cellSizeUnit: CGFloat = 80
+    private let cellSizeUnit: CGFloat = 100
     private var randomColorCollection = [UIColor]()
     
     override func viewDidLoad() {

--- a/PhotoApps/PhotoApps/ViewController.swift
+++ b/PhotoApps/PhotoApps/ViewController.swift
@@ -6,20 +6,28 @@
 //
 
 import UIKit
+import Photos
 
 class ViewController: UIViewController {
     
     @IBOutlet weak var collectionView: UICollectionView!
-    
-    private let numberOfItems = 40
+        
+    private var numberOfItems = 40
     private let cellSizeUnit: CGFloat = 100
     private var randomColorCollection = [UIColor]()
+    private var allPhotoAssets : PHFetchResult<PHAsset>?
     
     override func viewDidLoad() {
         super.viewDidLoad()
         randomColorCollection = generateRandomColors(count: numberOfItems)
         self.collectionView.delegate = self
         self.collectionView.dataSource = self
+        
+        self.allPhotoAssets = PHAsset.fetchAssets(with: .none)
+        self.numberOfItems = self.allPhotoAssets?.count ?? 0
+        
+        self.collectionView.reloadData()
+        
     }
     
     private func generateRandomColors(count: Int) -> [UIColor] {
@@ -48,9 +56,28 @@ extension ViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        
         let newCell = collectionView.dequeueReusableCell(withReuseIdentifier: "photoCell", for: indexPath) as! MyCustomViewCell
         
-        newCell.backgroundColor = randomColorCollection[indexPath.row]
+//        newCell.backgroundColor = randomColorCollection[indexPath.row]
+        
+        if let asset = allPhotoAssets?[numberOfItems - indexPath.row - 1] {
+            newCell.photoCellImageView.image = getAssetThumbnail(asset: asset)
+        }
+        
         return newCell
+    }
+    
+    func getAssetThumbnail(asset: PHAsset) -> UIImage {
+        let manager = PHImageManager()
+        let option = PHImageRequestOptions()
+        var thumbnail = UIImage()
+        option.isSynchronous = true
+        manager.requestImage(for: asset, targetSize: CGSize.init(width: cellSizeUnit, height: cellSizeUnit), contentMode: .aspectFit, options: .none) { (result, _ ) in
+            if let result = result {
+                thumbnail = result
+            }
+        }
+        return thumbnail
     }
 }

--- a/PhotoApps/PhotoApps/ViewController.swift
+++ b/PhotoApps/PhotoApps/ViewController.swift
@@ -19,17 +19,23 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         randomColorCollection = generateRandomColors(count: numberOfItems)
+        
         self.collectionView.delegate = self
         self.collectionView.dataSource = self
         
-        self.allPhotoAssets = PHAsset.fetchAssets(with: .none)
+        let targetAlbums = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumRecentlyAdded, options: .none)
+        
+        let album = targetAlbums.firstObject ?? PHAssetCollection()
+
+        self.allPhotoAssets = PHAsset.fetchAssets(in: album, options: .none)
         self.numberOfItems = self.allPhotoAssets?.count ?? 0
         
         self.collectionView.reloadData()
         
     }
-    
+
     private func generateRandomColors(count: Int) -> [UIColor] {
         var colorCollection = [UIColor]()
         

--- a/PhotoApps/PhotoApps/ViewController.swift
+++ b/PhotoApps/PhotoApps/ViewController.swift
@@ -25,7 +25,7 @@ class ViewController: UIViewController {
         self.collectionView.delegate = self
         self.collectionView.dataSource = self
         
-        let targetAlbums = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumRecentlyAdded, options: .none)
+        let targetAlbums = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .any, options: .none)
         
         let album = targetAlbums.firstObject ?? PHAssetCollection()
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,15 @@
 
 #### 2021.03.22 
 
-### Todays' 학습거리 📚
+### 구현 내용 📱
+
+- 무작위 색상의 배경을 가진 40개의 cell을 생성하고 세로 스크롤 Collection에 나타냈다.
+
+<img width="300" src="https://user-images.githubusercontent.com/52390975/111978184-fcc9fe80-8b46-11eb-9b65-ad75f21e9217.png">
+
+
+
+### Today's 학습거리 📚
 
 ##### 1. `CollectionView` 와 `CollecionViewCell` 에 대한 학습.
 
@@ -19,16 +27,18 @@
 - CollectionViewCell을 Custom화 시키기 위해 CustomCollectionViewCell 파일을 생성하고 CollectionView의 DataSource에서 해당 CustomCell을 reusableCell로 사용하였다.
 
 ##### 2. `CollectionView`와 `TableView`의 공통점과 차이점에 대한 학습
+
 - `공통점`
-   - DataSource와 Delegate 프로토콜을 이용한다.
-   - DataSource는 데이터 정보, 속성을 설정할 수 있으며, Delegate는 화면에서 보여지는 데이터를 관리한다.
+  - `DataSource`와 `Delegate` 프로토콜을 이용한다.
+  - `DataSource`는 데이터 정보, 속성을 설정할 수 있으며, `Delegate`는 화면에서 보여지는 데이터를 관리한다.
 - `차이점`
-   - 가장 큰 차이는 CollectionView엔 Custom Layout을 적용할 수 있다는 것이다.
-   - 레이아웃을 담당하는 프로토콜은 UICollectionViewDelegateFlowLayout로, 이 프로토콜의 메소드인 collectionView(:layout:sizeForItemAt:)을 사용하여 cell의 크기를 설정하였다. 
+  - 가장 큰 차이는 CollectionView엔 Custom Layout을 적용할 수 있다는 것이다.
+  - 레이아웃을 담당하는 프로토콜은 `UICollectionViewDelegateFlowLayout`로, 이 프로토콜의 메소드인 `collectionView(:layout:sizeForItemAt:)`을 사용하여 cell의 크기를 설정하였다. 
 
 ##### 3. 랜덤 컬러 설정하기 - `drand48()`
-   - drand48()와 UIColor의 rgba 이니셜라이저를 사용하여 랜덤 색상을 추출했다.
-   - drand48()은 [0.0, 1.0] 사이의 난수를 Double로 리턴하는 malloc 함수다.
+
+   - `drand48()`와 UIColor의 rgba 이니셜라이저를 사용하여 랜덤 색상을 추출했다.
+   - `drand48()`은 [0.0, 1.0] 사이의 난수를 Double로 리턴하는 malloc 함수다.
 
 
 ##### 4. 짝 프로그래밍을 경험하고 `Driver`와 `Navigator`가 되는 연습
@@ -39,4 +49,55 @@
 
 - 상대방의 코드를 pull, merge 하는 과정에서 많은 충돌이 있었고, 이 상황에서 다양한 대처법을 학습했다.
 
-<img width="300" src="https://user-images.githubusercontent.com/52390975/111978184-fcc9fe80-8b46-11eb-9b65-ad75f21e9217.png">
+<br>
+
+<br>
+
+## Step 2 : CollectionView에 PhotoLibrary 항목 표시
+
+#### 2021.03.23
+
+### 구현 내용 📱
+
+- PhotoLibrary의 콘텐츠 목록을 불러와서 표시하도록 구현
+- PhotoLibrary에 변화가 생길 시 수정 사항을 반영하여 목록을 업데이트하도록 구현
+
+<img width="300" src="https://user-images.githubusercontent.com/72188416/112140569-80ebb700-8c17-11eb-91e8-257a981e12b2.gif">
+
+<br>
+
+### Today's 학습거리 📚
+
+1. **`PhotoKit`을 통한 PhotoLibrary 연동 학습**
+
+   **주요 클래스**: `PHAsset`, `PHAssetCollection`, `PHCollectionList`, `PHCollection`, `PHFetchResult`, `PHImageManager`
+
+   - `PHAsset`과 `PHCachingImageManager`를 통해 PhotoLibrary에서 asset을 불러오고 thumbnail 이미지로 변환하여 cell에 적용하였다.
+
+   - `PHAssets`는 하나의 메타데이터를 가져온다. 메타데이터 옵션을 설정해서 image,video,audio 등등 중 하나의 속성값을 뽑아올 수 있다. `fetchAssets` 함수를 이용한다. 
+
+     ```swift
+     let photoAssets = PHAsset.fetchAssets(in: allContents, options: .none)
+     ```
+
+   -  `PHImageManager` 는 `PHAssets`의 메타데이터 정보를 관리한다. 일반적으로 `PHAssets`의 썸네일 이미지를 가져올 수 있으며, 사이즈를 재정의 할 수 있다.
+
+   -  `PHCachingImageManager`은 `PHImageManager`의 하위 클래스이며 대부분의 속성을 그대로 가져온다. 차이점은 한번에 여러 `PHAssets`를 가져오거나 관리를 할 수 있다.
+
+   - 이때, `PHImageRequestOption `객체를 통해 size 등의 옵션을 설정할 수 있다. 이 프로젝트에서는 resizeMode를 설정하여 이미지가 원하는 사이즈대로 표시될 수 있게 했다.
+
+   - `PHAssetCollection`을 통해 assetCollection 패치 시, UserPhotoLibrary의 다양한 앨범들을 불러와 보았다. `PHAssetCollection`을 통해 스마트앨범/일반 앨범을 불러오고, subType을 설정하여 앨범의 세부 타입(ex, 전체, 즐겨찾기, 셀카, 등등)을 선택해서 가져올 수 있다. `fetchAssetCollections` 함수를 이용한다.
+
+     ```swift
+     let smartAlbumCollection = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .any, options: .none)
+     ```
+
+2. **`PHPhotoLibraryChangeObserver` 프로토콜을 통한 옵저버 패턴 학습**
+
+   - PhotoKit에서 옵저버를 어떻게 등록하고 동작을 관찰할 수 있는 지 알게 되었다.
+   - `PHPhotoLibraryChangeObserver`에는 실시간으로 **PHAssets**의 변화를 감지하는 옵져버가 구성되어 있다.
+   - 변화 감지 시 작동되는 `photoLibraryDidChange(:PHChange)` 메소드의 changeInstance에서 필요한 정보를 추출하여 View에 적용하는 방식을 학습했다.
+
+3. **`performBatchUpdates`를 통한 `CollectionView` 업데이트**
+
+   - CollectionView가 제공하는 **insert/delete/reload/move** 기능을 통해 View를 효율적으로 업데이트하였다. 


### PR DESCRIPTION
PhotoLibrary 연동 기능 구현이 완료되어 PR을 보냅니다 :)

### 작업 목록
- [x] PhotoLibrary의 smartAlbum을 CollectionView에 연동
- [x] PhotoLibrary에 변경 사항이 있을 시 CollectionView를 업데이트

### 학습 키워드
🔑 PhotoKit
🔑 Observer

### 고민과 해결
- Thumbnail 사이즈 조정
  - PHImageManager를 통해 request 시 targetSize를 설정해주었는데도 사이즈가 뒤죽박죽으로 나타나는 문제가 발생했다.
  - PHImageRequestOption 객체를 통해 size를 고정할 수 있었다.
- PhotoLibrary의 콘텐츠를 시간 순으로 전부 불러오기
  - 처음엔 PHAssetCollection이 아닌 PHAsset으로 cell을 구성하여 이미지의 순서가 뒤죽박죽이었다.
  - PHAssetCollection의 smartAlbum을 통해 사진첩의 recent photos를 순서대로 전부 불러올 수 있었다.
- PhotoLibrary에 변화 후 CollectionView 업데이트 시 필요한 부분만 바꾸기
  - Asset을 전부 교체하고 다시 로드하는 방식은 비효율적.
  - CollectionView의 메소드인 performBatchUpdates를 통해 비효율을 해결할 수 있었다. 